### PR TITLE
V8: Composite doctype links don't go to the right place

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/umb-groups-builder.html
@@ -80,7 +80,7 @@
                         <i class="icon icon-merge"></i>
                         <localize key="contentTypeEditor_inheritedFrom"></localize>: {{ tab.inheritedFromName }}
                         <span ng-repeat="contentTypeName in tab.parentTabContentTypeNames">
-                            <a href="#/settings/documentTypes/edit/{{tab.contentTypeId}}">{{ contentTypeName }}</a>
+                            <a href="#/settings/documentTypes/edit/{{tab.parentTabContentTypes[$index]}}">{{ contentTypeName }}</a>
                             <span ng-if="!$last">, </span>
                         </span>
                     </div>


### PR DESCRIPTION
Links to inherited / composite doctype in the doctype builder redirect to the current doctype, not the doctype named in the link

### Steps to replicate

- [ ] Create a doctype
- [ ] Add more than one composition
- [ ] Next to each tab a composition adds, the name of the composition will appear - the name will be a link
- [ ] Click the link and it will redirect to the current doctype, not the composite doctype

If there's an existing issue for this PR then this fixes <!-- link to the issue here! -->